### PR TITLE
Changed how global variables are imported

### DIFF
--- a/rplacem/__init__.py
+++ b/rplacem/__init__.py
@@ -1,0 +1,79 @@
+
+import json, os
+from PIL import ImageColor
+import numpy as np
+
+
+class GlobalVars(object):
+    '''
+    Object containing global-level information on the canvas for a given year
+
+    attributes
+    ----------
+
+    methods
+    -------
+    '''
+
+    def __init__(self,
+                 year
+                 ):
+
+        self.year = year
+        self.TIME_TOTAL = 300590.208 if year == 2022 else 463089.865
+
+        self.TIME_WHITEOUT = 295410.186 if year == 2022 else 459028.647 # only white pixel changes allowed
+        self.TIME_GREYOUT = self.TIME_WHITEOUT if year == 2022 else 456227.910 # only white, black, and 3 nuances of grey allowed
+        self.TIME_16COLORS = 0 if year == 2022 else 116999.080
+        self.TIME_24COLORS = 99634.706 if year == 2022 else 277192.251
+        self.TIME_32COLORS = 195574.105 if year == 2022 else 361992.813
+        self.TIME_PARTIAL_240S_COOLDOWN = 273600 if year == 2023 else self.TIME_TOTAL # 2023 number from the reddit mod (Mikhail)
+        self.TIME_180S_AND_240S_COOLDOWN = self.TIME_GREYOUT if year == 2023 else self.TIME_TOTAL # 2023 info from the reddit mod (Mikhail)
+        self.TIME_120S_COOLDOWN = 459180 if year == 2023 else self.TIME_TOTAL # 2023 number from the reddit mod (Mikhail)
+        self.TIME_60S_COOLDOWN = 459420 if year == 2023 else self.TIME_TOTAL # 2023 number from the reddit mod (Mikhail)
+        self.TIME_30S_COOLDOWN = 460200 if year == 2023 else self.TIME_TOTAL # 2023 number from the reddit mod (Mikhail)
+
+        self.N_ENLARGE = 3 if year == 2022 else 7
+        self.TIME_ENLARGE = np.array([0, 99646.238, 195583.355]) if year == 2022 else \
+                            np.array([0, 97208.816, 155753.841, 208964.082, 277200.318, 305993.977, 362003.143])
+
+        # shape N_ENLARGE, 2 (x or y), 2 (min or max). The given min or max values are inclusive.
+        self.CANVAS_MINMAX = np.array([[[0, 999], [0, 999]], # initial canvas [[xmin, xmax], [ymin, ymax]]
+                                       [[0, 1999], [0, 999]], # x right
+                                       [[0, 1999], [0, 1999]]] # y bottom
+                                       ) if year == 2022 else \
+                             np.array([[[-500, 499], [-500, 499]], # initial canvas [[xmin, xmax], [ymin, ymax]]
+                                       [[-500, 999], [-500, 499]], # x right
+                                       [[-1000, 999], [-500, 499]], # x left
+                                       [[-1000, 999], [-1000, 499]], # y top
+                                       [[-1000, 999], [-1000, 999]], # y bottom
+                                       [[-1500, 999], [-1000, 999]], # x left
+                                       [[-1500, 1499], [-1000, 999]]]) # x right
+
+        self.COOLDOWN_MIN = 250
+
+        self.FILE_DIR = os.path.dirname(os.path.realpath(__file__))
+
+        self.DATA_PATH = os.path.join(self.FILE_DIR, '..', 'data', str(self.year))
+        self.FULL_DATA_FILE = 'PixelChangesCondensedData_sorted.npz'
+        self.FIGS_PATH = os.path.join(self.FILE_DIR, '..', 'figs', str(self.year))
+
+        self.COLOR_TO_IDX = json.load(open(os.path.join(self.DATA_PATH, 'ColorDict.json')))
+        self.IDX_TO_COLOR = json.load(open(os.path.join(self.DATA_PATH, 'ColorsFromIdx.json')))
+        self.WHITE = self.COLOR_TO_IDX['#FFFFFF']
+        self.BLACK = self.COLOR_TO_IDX['#000000']
+        self.PURPLE = self.COLOR_TO_IDX['#811E9F']
+        self.NUM_COLORS = len(self.COLOR_TO_IDX)
+
+        # set color dictionaries translating the color index to the corresponding rgb or hex color
+        self.COLIDX_TO_HEX = np.empty([self.NUM_COLORS], dtype='object')
+        self.COLIDX_TO_RGB = np.empty([self.NUM_COLORS, 3], dtype='int32')
+        for (k, v) in self.IDX_TO_COLOR.items(): # make these dictionaries numpy arrays, for more efficient use
+            self.COLIDX_TO_HEX[int(k)] = v
+            self.COLIDX_TO_RGB[int(k)] = np.asarray(ImageColor.getrgb(v))
+
+var = GlobalVars(year=2022)
+
+def set_year(year):
+    global var
+    var = GlobalVars(year=year)

--- a/rplacem/canvas_part.py
+++ b/rplacem/canvas_part.py
@@ -4,8 +4,7 @@ import pickle
 import cv2
 import numpy as np
 import matplotlib.pyplot as plt
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import rplacem.utilities as util
 import copy
 

--- a/rplacem/canvas_part_statistics.py
+++ b/rplacem/canvas_part_statistics.py
@@ -1,15 +1,15 @@
 import numpy as np
 import os
-import rplacem.globalvariables_peryear as vars
 import pandas as pd
-var = vars.var
 import rplacem.compute_variables as comp
 import rplacem.utilities as util
 import rplacem.transitions as tran
 import rplacem.time_series as ts
+from rplacem import var as var
 import shutil
 import warnings
 import math
+
 
 
 class CanvasPartStatistics(object):

--- a/rplacem/compute_variables.py
+++ b/rplacem/compute_variables.py
@@ -6,8 +6,7 @@ import seaborn as sns
 from PIL import Image
 import shutil
 import math
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import rplacem.utilities as util
 import rplacem.plot_utilities as plot
 import rplacem.entropy as entropy

--- a/rplacem/early_warning_signals.py
+++ b/rplacem/early_warning_signals.py
@@ -3,8 +3,7 @@ import os
 import rplacem.canvas_part as cp
 import rplacem.utilities as util
 import rplacem.canvas_part_statistics as stat
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import rplacem.transitions as trans
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/rplacem/machine_learning/EvalML.py
+++ b/rplacem/machine_learning/EvalML.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import matplotlib.pyplot as plt
 from scipy.integrate import simpson
 

--- a/rplacem/machine_learning/build_dataset.py
+++ b/rplacem/machine_learning/build_dataset.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pickle
 import os, sys
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import rplacem.transitions as tran
 import math
 import gc

--- a/rplacem/machine_learning/evaluation_per_composition.py
+++ b/rplacem/machine_learning/evaluation_per_composition.py
@@ -1,6 +1,5 @@
 import numpy as np
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import EvalML as eval
 import os
 import matplotlib.pyplot as plt

--- a/rplacem/machine_learning/xgboost_plotROC.py
+++ b/rplacem/machine_learning/xgboost_plotROC.py
@@ -1,7 +1,6 @@
 import json
 import matplotlib.pyplot as plt
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import os
 import pickle
 import numpy as np

--- a/rplacem/machine_learning/xgboost_regression.py
+++ b/rplacem/machine_learning/xgboost_regression.py
@@ -8,8 +8,7 @@ import matplotlib.colors as colors
 import matplotlib.colorbar as colorbar
 import seaborn as sns
 import matplotlib.pyplot as plt
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import gc
 from scipy.optimize import curve_fit
 from scipy.interpolate import UnivariateSpline

--- a/rplacem/plot_utilities.py
+++ b/rplacem/plot_utilities.py
@@ -6,8 +6,7 @@ from matplotlib.ticker import ScalarFormatter
 import mpl_toolkits.axes_grid1.inset_locator as insloc
 import seaborn as sns
 import os, copy
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import rplacem.utilities as util
 import numpy as np
 import math

--- a/rplacem/scaling.py
+++ b/rplacem/scaling.py
@@ -9,10 +9,9 @@ import scipy.odr
 import piecewise_regression
 import rplacem.canvas_part as cp
 import rplacem.entropy as ent
-import rplacem.globalvariables_peryear as vars
 import rplacem.utilities as util
+from rplacem import var as var
 
-var = vars.var
 
 def linear_model(params, x):
     return params[0] * x + params[1]

--- a/rplacem/time_series.py
+++ b/rplacem/time_series.py
@@ -1,8 +1,7 @@
 import numpy as np
 import os
 import pandas as pd
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import rplacem.plot_utilities as plot
 import rplacem.utilities as util
 import scipy.stats

--- a/rplacem/transitions.py
+++ b/rplacem/transitions.py
@@ -2,8 +2,7 @@ import numpy as np
 import rplacem.canvas_part as cp
 import rplacem.compute_variables as comp
 import rplacem.utilities as util
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import math
 from scipy import optimize
 

--- a/rplacem/utilities.py
+++ b/rplacem/utilities.py
@@ -3,8 +3,7 @@ import os
 import sys
 import numpy as np
 import glob
-import rplacem.globalvariables_peryear as vars
-var = vars.var
+from rplacem import var as var
 import json
 import shutil
 from PIL import Image


### PR DESCRIPTION
Now, to import the global variables, add:
```from rplacem import var as var```

if you want to change the global variables from the default 2022 to 2023, add into your driver script:

```
import rplacem
rplacem.set_year(2023)
```

Alternatively, you could go into __init__.py and change the default year to 2023. This is analogous to how we changed the years previously. 
